### PR TITLE
Filter null routes again

### DIFF
--- a/mrt/asn.go
+++ b/mrt/asn.go
@@ -78,6 +78,9 @@ func ASNFromBGP(appCacheDir string, ianaASN func(uint32) ir.IRID, rejectFile str
 				} else if inf != nil {
 					log.Logger.Debug("ignoring reserved range", zap.String("range", prefix))
 					continue
+				} else if prefix == "0.0.0.0/0" || prefix == "::/0" {
+					log.Logger.Debug("ignoring null route", zap.String("range", prefix))
+					continue
 				}
 				for _, entry := range ribMessage.Entries {
 					for _, pa := range entry.PathAttributes {


### PR DESCRIPTION
Further to changes in reserved range filtering they were not excluded anymore

```
$ diff asn6.zone.prev asn6.zone
227058d227057
< ::/0 25478|::/0|RU|ripencc|
$ diff asn4.zone.prev asn4.zone
3d2
< 0.0.0.0/0 55720|0.0.0.0/0|MY|apnic|
```